### PR TITLE
Correctly handle conversion of empty bytes objects

### DIFF
--- a/gc3libs/backends/transport.py
+++ b/gc3libs/backends/transport.py
@@ -1083,10 +1083,8 @@ class LocalTransport(Transport):
                 command, exitcode)
             # output and error streams are opened in binary mode, so
             # we must convert them into text strings
-            if stdout:
-                stdout = to_str(stdout, 'terminal')
-            if stderr:
-                stderr = to_str(stdout, 'terminal')
+            stdout = to_str(stdout, 'terminal')
+            stderr = to_str(stdout, 'terminal')
             return exitcode, stdout, stderr
         except Exception as ex:
             raise gc3libs.exceptions.TransportError(


### PR DESCRIPTION
The original intention of this code is to convert bytes objects into
strings.

However, the `if stdout` and `if stderr` tests originally employed here
fail when stdout or stderr is a zero length/empty bytes object i.e.
when equal to `b''`. These tests fail because an empty bytes object
evaluates to False. So empty bytes objects are currently not converted
to strings.

The failure only occurs in Python 3. In Python 3, bytes is a different
type than string whereas in Python 2 the bytes class is simply an
alias for the string class.