### PR TITLE
Add additional SGE time format

### DIFF
--- a/gc3libs/backends/sge.py
+++ b/gc3libs/backends/sge.py
@@ -133,6 +133,7 @@ def _parse_asctime(val):
     for fmt in [
             '%a %b %d %H:%M:%S %Y',  # standard asctime() format
             '%m/%d/%Y %H:%M:%S',     # sge_ctime()
+            '%m/%d/%Y %H:%M:%S.%f',  # sge_ctime() including milliseconds
             '%Y-%m-%dT%H:%M:%S',     # ISO 8601 / sge_ctimeXML()
     ]:
         try:


### PR DESCRIPTION
Following on from #632, Univa 8.6.8 (and perhaps earlier versions)
uses a timestamp in the format:

```
02/11/2020 17:01:16.346
```

This is similar to the existing sge_ctime() format introduced in
commit https://github.com/gc3pie/gc3pie/commit/fc88353ba3e681388e134addf9e435961efddee3 but with the addition of milliseconds.

This commit adds an additional format that parses the sge_ctime
format with milliseconds included.