### PR TITLE
Add custom private key specification

### DIFF
--- a/gc3libs/authentication/ssh.py
+++ b/gc3libs/authentication/ssh.py
@@ -24,6 +24,10 @@ from builtins import object
 __docformat__ = 'reStructuredText'
 
 
+import io
+
+import paramiko
+
 import gc3libs
 import gc3libs.defaults
 from gc3libs.authentication import Auth
@@ -38,6 +42,7 @@ class SshAuth(object):
                  # SSH-specific arguments
                  username,
                  keyfile=None,
+                 pkey=None,
                  port=None,
                  ssh_config=None,
                  timeout=None,
@@ -53,6 +58,7 @@ class SshAuth(object):
         # (no sensible default)
         self.keyfile = keyfile
 
+        self.pkey = paramiko.RSAKey.from_private_key(io.StringIO(pkey)) if pkey else None
         if ssh_config is not None:
             self.ssh_config = ssh_config
         else:

--- a/gc3libs/authentication/ssh.py
+++ b/gc3libs/authentication/ssh.py
@@ -58,7 +58,7 @@ class SshAuth(object):
         # (no sensible default)
         self.keyfile = keyfile
 
-        self.pkey = paramiko.RSAKey.from_private_key(io.StringIO(pkey)) if pkey else None
+        self.pkey = pkey
         if ssh_config is not None:
             self.ssh_config = ssh_config
         else:

--- a/gc3libs/backends/batch.py
+++ b/gc3libs/backends/batch.py
@@ -124,6 +124,7 @@ class BatchSystem(LRMS):
                  # SSH-related options; ignored if `transport` is 'local'
                  ssh_config=None,
                  keyfile=None,
+                 pkey=None,
                  ignore_ssh_host_keys=False,
                  ssh_timeout=None,
                  large_file_threshold=None,
@@ -153,6 +154,7 @@ class BatchSystem(LRMS):
                 username=self._username,
                 port=auth.port,
                 keyfile=(keyfile or auth.keyfile),
+                pkey=auth.pkey,
                 timeout=(ssh_timeout or auth.timeout),
                 large_file_threshold=large_file_threshold,
                 large_file_chunk_size=large_file_chunk_size,

--- a/gc3libs/backends/batch.py
+++ b/gc3libs/backends/batch.py
@@ -124,7 +124,6 @@ class BatchSystem(LRMS):
                  # SSH-related options; ignored if `transport` is 'local'
                  ssh_config=None,
                  keyfile=None,
-                 pkey=None,
                  ignore_ssh_host_keys=False,
                  ssh_timeout=None,
                  large_file_threshold=None,

--- a/gc3libs/backends/transport.py
+++ b/gc3libs/backends/transport.py
@@ -457,6 +457,30 @@ class SshTransport(Transport):
         Additional arguments ``user``, ``port``, ``keyfile``, and
         ``timeout``, if given, override the above settings.
 
+        `pkey` is a reference to a `paramiko.pkey.PKey` object.
+        If specified, `pkey` will be used for authentification to
+        the remote resource, much like the `pkey` argument to
+        `paramiko.client.SSHClient.connect()`. This is useful for
+        any case where the key is already in memory, as writing it
+        to a file can be avoided. Any subclass of `paramiko.pkey.PKey`
+        (`DSSKey`, `RSAKey`, `ECDSAKey`, and `Ed25519Key`) can be passed
+        in. Because of this, this option cannot be set via a config file.
+        This option can be set, however from a `create_engine` call, passing
+        in a `cfg_dict` with `pkey` as a parameter to any `auth` section.
+        See below example::
+
+        Setting `pkey` from `create_engine`
+
+        >>> import gc3libs, io, paramiko
+        >>> d = dict()
+        >>> gen_key = paramiko.RSAKey.generate(bits=4096)
+        >>>
+        >>> d["DEFAULT"] = {"debug": 0}
+        >>> d["auth/ssh_bob"] = {
+        ... "type": "ssh", "username": "your_ssh_user_name_on_computer_bob",
+        ... "pkey": gen_key, "foo": "5"}
+        >>> engine = gc3libs.create_engine(cfg_dict=d)
+
         Finally, the two parameters `large_file_threshold` and
         `large_file_chunk_size` control how file copy is being made:
         if a file is larger than `large_file_threshold`, then it will

--- a/gc3libs/backends/transport.py
+++ b/gc3libs/backends/transport.py
@@ -425,7 +425,8 @@ class SshTransport(Transport):
                  ignore_ssh_host_keys=False,
                  ssh_config=None,
                  username=None, port=None,
-                 keyfile=None, timeout=None,
+                 keyfile=None, pkey=None,
+                 timeout=None,
                  large_file_threshold=None,
                  large_file_chunk_size=None,
                  **extra_args):
@@ -473,6 +474,7 @@ class SshTransport(Transport):
         # init connection params
         self.username = None
         self.keyfile = None
+        self.pkey = None
         self.port = gc3libs.defaults.SSH_PORT
         self.timeout = gc3libs.defaults.SSH_CONNECT_TIMEOUT
         self.proxy_command = None
@@ -483,7 +485,7 @@ class SshTransport(Transport):
         if os.path.exists(config_filename):
             with open(config_filename, 'r') as config_file:
                 self._ssh_config.parse(config_file)
-        self.set_connection_params(remote_frontend, username, keyfile, port, timeout)
+        self.set_connection_params(remote_frontend, username, keyfile, pkey, port, timeout)
 
         # SSH copy size params; convert to int for more efficiency at time of use
         self.large_file_threshold = self._memory_to_bytes(
@@ -531,7 +533,7 @@ class SshTransport(Transport):
                 .format(qty, type(qty)))
 
     def set_connection_params(self, hostname, username=None, keyfile=None,
-                               port=None, timeout=None):
+                               pkey=None, port=None, timeout=None):
         """
         Set remote host name and other parameters used for new connections.
         Currently-established connections are not affected.
@@ -568,6 +570,8 @@ class SshTransport(Transport):
             self.timeout = float(ssh_options.get('connecttimeout', self.timeout))
         else:
             self.timeout = float(timeout)
+
+        self.pkey = pkey
 
         # support for extra configuration options, not having a direct
         # equivalent in the GC3Pie configuration file
@@ -627,6 +631,7 @@ class SshTransport(Transport):
                                  timeout=self.timeout,
                                  username=self.username,
                                  port=self.port,
+                                 pkey=self.pkey,
                                  allow_agent=True,
                                  key_filename=self.keyfile,
                                  sock=proxy)

--- a/gc3libs/backends/transport.py
+++ b/gc3libs/backends/transport.py
@@ -498,7 +498,7 @@ class SshTransport(Transport):
         # init connection params
         self.username = None
         self.keyfile = None
-        self.pkey = None
+        self.pkey = pkey
         self.port = gc3libs.defaults.SSH_PORT
         self.timeout = gc3libs.defaults.SSH_CONNECT_TIMEOUT
         self.proxy_command = None
@@ -509,7 +509,7 @@ class SshTransport(Transport):
         if os.path.exists(config_filename):
             with open(config_filename, 'r') as config_file:
                 self._ssh_config.parse(config_file)
-        self.set_connection_params(remote_frontend, username, keyfile, pkey, port, timeout)
+        self.set_connection_params(remote_frontend, username, keyfile, port, timeout)
 
         # SSH copy size params; convert to int for more efficiency at time of use
         self.large_file_threshold = self._memory_to_bytes(
@@ -557,7 +557,7 @@ class SshTransport(Transport):
                 .format(qty, type(qty)))
 
     def set_connection_params(self, hostname, username=None, keyfile=None,
-                               pkey=None, port=None, timeout=None):
+                               port=None, timeout=None):
         """
         Set remote host name and other parameters used for new connections.
         Currently-established connections are not affected.
@@ -594,8 +594,6 @@ class SshTransport(Transport):
             self.timeout = float(ssh_options.get('connecttimeout', self.timeout))
         else:
             self.timeout = float(timeout)
-
-        self.pkey = pkey
 
         # support for extra configuration options, not having a direct
         # equivalent in the GC3Pie configuration file


### PR DESCRIPTION
Allow users to specify their own private key when connecting through ssh. Similar to the `pkey` argument in `paramiko`'s `client.connect` method.